### PR TITLE
Fix #6, don't persist duplicate tag-report pairs

### DIFF
--- a/bot/src/db.js
+++ b/bot/src/db.js
@@ -24,7 +24,9 @@ export async function setTags(ts, tags) {
   return await db.query(
     `INSERT INTO "tag"(report, tag)
      SELECT $1 id, t
-     FROM unnest($2::text[]) t`,
+     FROM unnest($2::text[]) t
+     ON CONFLICT ON CONSTRAINT tag_tag_report_unique
+     DO NOTHING`,
     [ts, tags],
   )
 }

--- a/migrations/20190725092624_add_unique_constraint_to_tag_table.js
+++ b/migrations/20190725092624_add_unique_constraint_to_tag_table.js
@@ -1,0 +1,21 @@
+
+exports.up = async (knex) => {
+  await knex.raw(`
+    DELETE FROM
+      Tag a
+        USING Tag b
+    WHERE
+      a.id > b.id
+      AND a.tag = b.tag
+      AND a.report = b.report;`)
+
+  await knex.schema.alterTable('tag', function(table) {
+    table.unique(['tag', 'report'])
+  })
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('tag', function(table) {
+    table.dropUnique(['tag', 'report'])
+  })
+};


### PR DESCRIPTION
The bot can get into a state, where it saves the same tag-report pair more than once. This change prevents this by introducing a unique constraint for _Tag_ table on tag and report columns. Since, the insertion of duplicates would fail by violating the newly introduced constraint, from now on it will just skip them.