### PR TITLE
Fix #7, scroll to the bottom in the message list

### DIFF
--- a/client/src/components/message/MessageList.js
+++ b/client/src/components/message/MessageList.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import {Link} from '../ui'
 import MessageContent from './MessageContent'
 import ParentPreview from './ParentPreview'
@@ -8,15 +8,42 @@ import * as routes from '../../routes'
 
 import './MessageList.scss'
 
-function MessageList({customEmojis, reports, users, channels}) {
-  return (
-    <div className="MessageList">
-      {
-        reports.map(report => (<MessageItem key={report.id} message={report} users={users} channels={channels} customEmojis={customEmojis} />))
-      }
-    </div>
-  )
+class MessageList extends Component {
+
+  endOfList = React.createRef()
+
+  scrollToBottom = () => {
+    this.endOfList.current.scrollIntoView()
+  }
+  
+  componentDidMount() {
+    this.scrollToBottom()
+  }
+  
+  componentDidUpdate() {
+    this.scrollToBottom()
+  }
+
+  render () {
+    return (
+      <div className="MessageList">
+        {this.props.reports.map (report => (
+          <MessageItem
+            key={report.id}
+            message={report}
+            users={this.props.users}
+            channels={this.props.channels}
+            customEmojis={this.props.customEmojis}
+          />
+        ))}
+        {/* https://stackoverflow.com/questions/37620694/how-to-scroll-to-bottom-in-react */}
+        <div style={{ float:"left", clear: "both" }} ref={this.endOfList}>
+        </div>
+      </div>
+    )
+  }
 }
+
 
 export default MessageList
 


### PR DESCRIPTION
The user wants to see the latest messages first. Since the ordering reflects Slack's ordering (i. e. from oldest to latest), UI needs to automatically scroll down to the latest message.