### PR TITLE
Fix #10, load all unprocessed messages on startup

### DIFF
--- a/bot/src/db.js
+++ b/bot/src/db.js
@@ -20,6 +20,12 @@ export async function deleteReport(ts) {
   return await db.query('DELETE FROM "report" WHERE ts=$1', [ts])
 }
 
+export async function getLatestReportsByChannel() {
+  return (await db.query(
+    'SELECT channel, MAX(ts) latest FROM report GROUP BY channel'
+  )).rows
+}
+
 export async function setTags(ts, tags) {
   return await db.query(
     `INSERT INTO "tag"(report, tag)


### PR DESCRIPTION
When the bot is not running, new messages could appear in the watched channels. These messages are left unprocessed since the bot is triggered only on a new message event. This issue fixes this problem
by looping through all the channels the bot is a member of on every startup. For each channel, the latest message stored in the database determines which message was the last one processed, every newer message is loaded to the database.