### PR TITLE
Fix the emoji in the message list header

### DIFF
--- a/client/src/components/topPanel/TopPanel.js
+++ b/client/src/components/topPanel/TopPanel.js
@@ -3,12 +3,14 @@ import { Emoji } from '../ui'
 import './TopPanel.scss'
 
 function TopPanel({ customEmojis, selectedTag }) {
-  const showEmoji = selectedTag in customEmojis
+  const emojiSpecialName = `__${selectedTag}`
+  const showEmoji = emojiSpecialName in customEmojis
 
   return (
     <div className="TopPanel">
-      { showEmoji && <Emoji className="emoji" name={selectedTag} customEmojis={customEmojis} /> }
-      <h2 className="title">{selectedTag}</h2>
+      <h2 className="title">
+        { showEmoji && <Emoji className="emoji" name={emojiSpecialName} customEmojis={customEmojis} /> } {selectedTag}
+      </h2>
     </div>
   )
 }


### PR DESCRIPTION
The corresponding emoji of the selected tag is shown in the header incorrectly. The corresponding emojis of these special tags are prefixed with two underscores in Slack. This fact was not taken into consideration in the code before. Also, for more pleasing visuals, the emoji was moved to the h2 element.