### PR TITLE
Fix #5, cache Slack data on the server

### DIFF
--- a/server/src/cache.js
+++ b/server/src/cache.js
@@ -1,0 +1,12 @@
+export function create(load) {
+  return {
+    storage: Object.create(null),
+    load,
+  }
+}
+
+export async function get(cache, key, args) {
+  const update = cache.load(key, args).then((v) => {cache.storage[key] = v})
+  if (cache.storage[key] === undefined) await update
+  return cache.storage[key]
+}


### PR DESCRIPTION
Querying Slack's API is a speed bottleneck of the server. The new solution will introduce in-memory storage. This storage will be used primarily to retrieve the data which was otherwise collected from Slack. If the data is present, it will be sent to the client. If the data is not present, it will be queried from Slack. The storage will update itself asynchronously on every request. This means it could return out-dated data.