### PR TITLE
Load and serve users mentioned in replies

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -95,7 +95,10 @@ app.get('/api/reports-by-tags/:tag', authorize, async (req, res) => {
 
   const authors = reports.map((r) => r.user)
   const replyAuthors = [].concat(...reports.map((t) => t.replies.map((r) => r.user)))
-  const allMentions = [].concat(...reports.map((r) => mentions(r.message)))
+  const allMentions = 
+    [].concat(...reports.map(
+      (report) => [].concat(...report.replies.map(
+        (reply) => mentions(reply.text)))))
   const userIds = Array.from(new Set([...authors, ...replyAuthors, ...allMentions]))
   const channelIds = Array.from(new Set(reports.map((r) => r.channel)))
 


### PR DESCRIPTION
The previous implementation only loaded users mentioned in reports.
This caused the client to crash when a report replied to a
non-report message mentioning some user, because we display
the starting message of a thread, even if it's not a report.
The starting message is also included when querying replies, so
it's enough to search for mentions in replies.

Fixes #30.