### PR TITLE
Prevent depolyment freezing when idle

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,15 @@
 {
     "alias": ["report.vacuumlabs.com"],
-
+    "scale": {
+        "bru1": {
+            "min": 1,
+            "max": "auto"
+        },
+        "sfo1": {
+            "min": 1,
+            "max": "auto"
+        }
+    },
     "env": {
         "NODE_ENV":"production",
 


### PR DESCRIPTION
Setting the minimum number of instances to 1 makes sure the
deployment is never frozen, even if no requests come in.
The region name could be "all", but that doesn't seem to prevent
freezing, and there are only these 2 regions for Now v1.

Fixes #28.