### PR TITLE
Fix auth redirect

### DIFF
--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -10,7 +10,7 @@ export const setupAuthentication = () => {
   }
 
   const renderError = (message) => {
-    ReactDOM.render(<div>{message}</div>, rootElement)
+    ReactDOM.render(<div className="error">{message}</div>, rootElement)
   }
 
   axios.interceptors.response.use(undefined, (error) => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -13,3 +13,7 @@ body {
 #root {
   height: 100%;
 }
+
+.error {
+  color: white;
+}

--- a/now.json
+++ b/now.json
@@ -15,5 +15,11 @@
         "required_team_id": "2509915",
         "VL_SSO_KEY": "@vl-sso-key",
         "VL_SSO_URL": "https://sso.vacuumlabs.com"
+    },
+
+    "build": {
+        "env": {
+            "REACT_APP_LOGIN_URL": "/auth/login"
+        }
     }
 }


### PR DESCRIPTION
 Set default for env var: REACT_APP_LOGIN_URL

The client expected this env var, and went into a redirect loop
if it wasn't present. Adding it to transenv with the appropriate
default value and reading it from config fixes this problem.

