### PR TITLE
Execute commands in updated messages

### DIFF
--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -38,17 +38,17 @@ export function getTags(message) {
 
 export async function handleCommands(event, web) {
   const {botToken} = config.slack
-  const {text: message, channel, ts} = event
+  const {message, channel, ts: messageTs, eventTs = messageTs} = event
   let isCommand = false
   for (const {pattern, action} of commands) {
     const match = message.match(pattern)
     if (!match) continue
     logger.debug(`executing ${match[0]}`)
-    await action(match, message, ts)
+    await action(match, message, eventTs)
     await web.reactions.add({
       token: botToken,
       channel,
-      timestamp: ts,
+      timestamp: messageTs,
       name: 'heavy_check_mark',
     })
     isCommand = true

--- a/migrations/20200416111808_add_not_nullable_to_is_command.js
+++ b/migrations/20200416111808_add_not_nullable_to_is_command.js
@@ -1,0 +1,21 @@
+
+exports.up = async (knex) => {
+  await knex.schema.alterTable('tagged', (table) => {
+    table
+      .boolean('is_command')
+      .comment('Indicates whether the tagged report is a command.')
+      .defaultTo('false')
+      .notNullable()
+      .alter()
+  })
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('tagged', (table) => {
+    table
+      .boolean('is_command')
+      .comment('Indicates whether the tagged report is a command.')
+      .defaultTo('false')
+      .alter()
+  })
+};


### PR DESCRIPTION
On message update we scan the modified text of the message and
execute any commands found. We still not revert the effect of
the old command, if the message was a command.
Issue #46 was caused by not filling the is_command column on update.

Fixes #46