### PR TITLE
Unarchive tags on new message

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ $ yarn build && yarn start
 /remove @ReportBot 
 ```
 
+  * If you want to (un)archive some projects you can run the command:
+
+```
+(un)archive [tag1] [tag2] ... [tagN]
+```
+
+  * If you want to change project's name to red, if there was no activity from set period (default is 16 days), you can run the command:
+
+```
+frequency [tag1] [frequency1] [tag2] [frequency2] ... [tagN] [frequency2]
+```
+
   * To categorize the message under some tag you can use special tags in the format `:__some-tag:`.
 
 ## 5 Server application

--- a/bot/src/slack.js
+++ b/bot/src/slack.js
@@ -3,7 +3,7 @@ import {RTMClient} from '@slack/rtm-api'
 import {WebClient} from '@slack/web-api'
 import logger from './logger'
 import config from './config'
-import {upsertReport, deleteReport, setTags, clearTags, getLatestReportsByChannel} from './db'
+import {upsertReport, deleteReport, setTags, clearTags, getLatestReportsByChannel, archive} from './db'
 import {getTags, handleCommands} from './commands'
 
 const {appToken, botToken} = config.slack
@@ -28,6 +28,9 @@ const addMessage = async (event) => {
 
   if (tags.length) {
     await setTags(ts, tags, isCommand)
+    if (!isCommand) {
+      await archive(tags, false, ts) // unarchive tags
+    }
   }
 }
 


### PR DESCRIPTION
Addresses issue #47

I was thinking of using `archive` method with parameter `is_archived=false` only in case the tag was archived previously, but it requires two sql queries or another approach would be to create a new method `unarchive` with more complex sql statement. This was the simplest solution as we probably don't care if `archived_timestamp` is changed even if the tag was not archived in its previous state. Your thoughts?