### PR TITLE
Fix crash on fetching a deleted channel's info

### DIFF
--- a/client/src/components/message/MessageList.js
+++ b/client/src/components/message/MessageList.js
@@ -53,7 +53,7 @@ function MessageItem({message, customEmojis, users, channels}) {
   const firstReplyAuthor = message.replies.length >= 2 && users[message.replies[1].user]
   const responseTo = message.response_to
   const channel = channels[message.channel]
-  const channelName = (channel.is_channel ? '#' : '🔒') + channel.name
+  const channelName = channel ? (channel.is_channel ? '#' : '🔒') + channel.name : `#${message.channel}`
   const dateTime = formatTs(message.ts)
   const replyCount = message.replies.length - 1
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -16,7 +16,7 @@ const web = new WebClient(config.slack.appToken)
 
 const indexById = (array) => {
   return array.reduce(
-    (acc, row) => Object.assign(acc, {[row.id]: row}),
+    (acc, row) => row ? Object.assign(acc, {[row.id]: row}) : acc,
     Object.create(null)
   )
 }
@@ -26,8 +26,12 @@ const users = cache.create(async (user) => {
   return {...u.profile, id: user}
 })
 const channels = cache.create(async (channel) => {
-  const c = await web.conversations.info({channel})
-  return c.channel
+  const c = await web.conversations.info({channel}).catch((error) => {
+    if (error.data.error !== 'channel_not_found') {
+      throw error
+    }
+  })
+  return c ? c.channel : null
 })
 const emojis = cache.create(() => web.emoji.list())
 


### PR DESCRIPTION
The server crashed if it tried to fetch a deleted channel when
loading message data. This is the only (probable) reason why the
query can fail, as it can get the info about archived channels
and channels it's been kicked from.