### PR TITLE
Fix server crash on missing user

### DIFF
--- a/client/src/components/message/MessageContent.js
+++ b/client/src/components/message/MessageContent.js
@@ -40,7 +40,10 @@ class MessageContent extends Component {
       code: ({text}, k) => rich ? <code key={k}>{text}</code> : text,
       emoji: ({id}, k) => <Emoji name={id} customEmojis={customEmojis} key={k}/>,
       user: ({id}, k) => {
-        const name = `@${users[id].display_name}`
+        if (!users[id]) {
+          return `@${id}`
+        }
+        const name = `@${users[id].display_name || users[id].real_name}`
         return rich
           ? <Link className="userLink" to={routes.user(id)} key={k}>{name}</Link>
           : name

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -22,8 +22,12 @@ const indexById = (array) => {
 }
 
 const users = cache.create(async (user) => {
-  const u = await web.users.profile.get({user})
-  return {...u.profile, id: user}
+  const u = await web.users.profile.get({user}).catch((error) => {
+    if (error.data.error !== 'user_not_found') {
+      throw error
+    }
+  })
+  return u ? {...u.profile, id: user} : null
 })
 const channels = cache.create(async (channel) => {
   const c = await web.conversations.info({channel}).catch((error) => {


### PR DESCRIPTION
Fixes #54
Practice shows it's possible that a user mentioned in a message can't be queried by the bot through the API, causing the server to crash.
From the [docs](https://slack.com/intl/en-hu/help/articles/204475027-Deactivate-a-members-account) it seems like users can't be deleted entirely (just deactivated), so I guess the user (`U013G2ZH7EF`) is some special guest whom the bot hasn't right to access.
