### PR TITLE
Store only report related messages

### DIFF
--- a/bot/src/db.js
+++ b/bot/src/db.js
@@ -16,8 +16,24 @@ export async function upsertReport({
   )
 }
 
+export async function updateReport({ts, message}) {
+  return await db.query(
+    'UPDATE "report" SET message = $2 WHERE ts = $1',
+    [ts, message]
+  )
+}
+
 export async function deleteReport(ts) {
   return await db.query('DELETE FROM "report" WHERE ts=$1', [ts])
+}
+
+export async function isReport(ts) {
+  return (await db.query(
+    `SELECT COUNT(*)
+     FROM report JOIN tagged on report.ts = tagged.report
+     WHERE ts=$1`,
+    [ts]
+  )).rows[0].count > 0
 }
 
 export async function getLatestReportsByChannel() {

--- a/migrations/20200910155302_remove_non_report_messages.js
+++ b/migrations/20200910155302_remove_non_report_messages.js
@@ -1,0 +1,15 @@
+
+exports.up = async (knex) => {
+  const report = knex('tagged').distinct('report')
+  const reply_to_report = knex('report').whereIn('response_to', report).select('ts')
+  const replied_by_report =
+    knex('report').whereIn('ts', report).whereNotNull('response_to').distinct('response_to')
+
+  await knex('report')
+    .whereNotIn('ts', report)
+    .whereNotIn('ts', reply_to_report)
+    .whereNotIn('ts', replied_by_report)
+    .del()
+}
+
+exports.down = async (knex) => {};


### PR DESCRIPTION
#56

Storing every single message the bot sees makes the DB needlessly large.
We should store only messages related to displaying reports.
These are:
 * messages with at least one project tag (reports)
 * replies to reports, as we show the number of replies and
   the first reply's author
 * messages replied by reports, as we show the thread root
   message if a report is sent in a thread

We also need to handle the editing of non-report messages that become
a report, and that are replied by reports. Other non-report edits should
be ignored.

I'll make a DB snapshot before merging. :slightly_smiling_face: 